### PR TITLE
Support expanded user configuration via `REGISTRY_USERS` and `REGISTRY_RO_USERS`.

### DIFF
--- a/.profile.d/gen-htpasswd.sh
+++ b/.profile.d/gen-htpasswd.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
-set -ex
 
-echo -e "${REGISTRY_USERNAME}:$(perl -le 'print crypt($ENV{"REGISTRY_PASSWORD"}, rand(0xffffffff));')" > /app/config/docker-registry.htpasswd
+set -e
+
+$HOME/bin/gen-htpasswd "$REGISTRY_USERNAME:$REGISTRY_PASSWORD,$REGISTRY_USERS" > /app/config/docker-registry.htpasswd
+$HOME/bin/gen-htpasswd "$REGISTRY_USERNAME:$REGISTRY_PASSWORD,$REGISTRY_USERS,$REGISTRY_RO_USERS" > /app/config/docker-registry-ro.htpasswd

--- a/.profile.d/touch-nginx-file.sh
+++ b/.profile.d/touch-nginx-file.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -e
 
 mkdir -p /app/logs/nginx
 touch /tmp/app-initialized

--- a/README.md
+++ b/README.md
@@ -31,3 +31,16 @@ index.  The included `config.yml` file is used to wire up bugsnag api tokens
 and the `DATABASE_URL` db uri.
 
 Please file issues and send PRs.
+
+## Advanced user configuration
+
+`app.json` sets `REGISTRY_USERNAME` and `REGISTRY_PASSWORD` which have full
+read and write access to the registry. For more fine-grained control, these
+configs are also respected:
+
+* `REGISTRY_USERS`: a `,`-separated list of `username:password` pairs. These users have full access to the registry. Example: `greg:hithere,dan:hello`
+* `REGISTRY_RO_USERS`: a `,`-separated list of `username:password` pairs. These users have read-only access to the registry. Example: `build:secret,deploy:moresecret`
+
+`REGISTRY_RO_USERS` is useful for use with build and deploy authentication where
+pushing to the registry is not required. Items in `REGISTRY_USERS` are merged with
+`REGISTRY_RO_USERS` so there should be no overlap between them.

--- a/bin/gen-htpasswd
+++ b/bin/gen-htpasswd
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+
+require "securerandom"
+
+credentials = ARGV.first
+unless credentials
+  $stderr.puts "#$0: need credentials"
+  exit 1
+end
+
+def expand(s)
+  s.split(",").map {|u_p| u_p.split(":") }
+end
+
+def clean(l)
+  l.reject {|(u, p)| u.nil? || u.strip.empty? || p.nil? || p.strip.empty? }
+end
+
+def encrypt(l)
+  l.map {|(u, p)| [u, p.crypt(SecureRandom.hex(2))] }
+end
+
+def htpasswd(l)
+  l.map {|c| c.join(":") }
+end
+
+puts htpasswd(encrypt(clean(expand(credentials))))

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -15,7 +15,7 @@ http {
 
   server_tokens off;
 
-  log_format l2met 'measure#nginx.service=$request_time request_id=$http_x_request_id';
+  log_format l2met 'measure#nginx.service=$request_time request_id=$http_x_request_id remote_user=$remote_user';
   access_log logs/nginx/access.log l2met;
   error_log logs/nginx/error.log;
 
@@ -42,7 +42,12 @@ http {
 
     location / {
       auth_basic              "Restricted";
-      auth_basic_user_file    docker-registry.htpasswd;
+      auth_basic_user_file    docker-registry-ro.htpasswd;
+
+      limit_except GET {
+        auth_basic              "Restricted";
+        auth_basic_user_file    docker-registry.htpasswd;
+      }
 
       include docker-registry.conf;
     }


### PR DESCRIPTION
`REGISTRY_USERNAME`/`REGISTRY_PASSWORD` are good for getting started but limiting push access to just where it's needed is preferable. This PR introduces `REGISTRY_USERS` and `REGISTRY_RO_USERS` which allow listing of `username:password` pairs. `RO` users have read-only access with the intention they can be used by automation for pulling images. The credentials in `REGISTRY_USERNAME`/`REGISTRY_PASSWORD` and listed in `REGISTRY_USERS` have read and write access.

Longer term it would be nice to be able to wrap access to the registry in something that authenticates and authorizes access more dynamically, such as against postgres or DynamoDB.
